### PR TITLE
Spread inputs in cn function for improved handling

### DIFF
--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -2,5 +2,5 @@ import { clsx, type ClassValue } from "clsx";
 import { twMerge } from "tailwind-merge";
 
 export function cn(...inputs: ClassValue[]) {
-  return twMerge(clsx(inputs));
+  return twMerge(clsx(...inputs));
 }


### PR DESCRIPTION

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR fixes a bug in the `cn` utility function where the inputs array was being passed directly to `clsx` instead of being spread. The change from `clsx(inputs)` to `clsx(...inputs)` ensures that each class value is passed as a separate argument, allowing `clsx` to properly handle and merge the class names.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `src/lib/utils.ts` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Spread inputs in the `cn` utility when calling `clsx` so each class value is handled individually and then merged by `tailwind-merge`. This prevents incorrect class merging when arrays are passed and ensures expected Tailwind class resolution.

<sup>Written for commit 4854f859edbfb7e741bdaeceaa3b939c62852325. Summary will update on new commits. <a href="https://cubic.dev/pr/midnghtsapphire/neurooz/pull/20?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

